### PR TITLE
chore(barretenberg): Restore brew builds

### DIFF
--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -60,6 +60,6 @@ cd ..
 
 # Build WASM.
 mkdir -p build-wasm && cd build-wasm
-cmake -DTOOLCHAIN=wasm32-wasi -DTESTING=OFF ..
+cmake -DTOOLCHAIN=wasm32-wasi -DTESTING=OFF -DWASI_SDK_PREFIX=./src/wasi-sdk-12.0 ..
 cmake --build . --parallel --target barretenberg.wasm
 cd ..

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -48,7 +48,7 @@ fi
 
 # Build native.
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithAssert -DTOOLCHAIN=$TOOLCHAIN -DTESTING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=RelWithAssert -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchains/$TOOLCHAIN.cmake -DTESTING=OFF ..
 cmake --build . --parallel
 cd ..
 
@@ -60,6 +60,6 @@ cd ..
 
 # Build WASM.
 mkdir -p build-wasm && cd build-wasm
-cmake -DTOOLCHAIN=wasm32-wasi -DTESTING=OFF -DWASI_SDK_PREFIX=./src/wasi-sdk-12.0 ..
+cmake -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchains/wasm32-wasi.cmake -DTESTING=OFF -DWASI_SDK_PREFIX=./src/wasi-sdk-12.0 ..
 cmake --build . --parallel --target barretenberg.wasm
 cd ..

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -34,15 +34,15 @@ if [ "$OS" == "macos" ]; then
         exit 1
     fi
     if [ "$ARCH" = "arm64" ]; then
-        TOOLCHAIN=arm-apple-clang
+        TOOLCHAIN=aarch64-darwin
     else
-        TOOLCHAIN=x86_64-apple-clang
+        TOOLCHAIN=x86_64-darwin
     fi
 else
     if [ "$ARCH" = "aarch64" ]; then
-        TOOLCHAIN=aarch64-linux-clang
+        TOOLCHAIN=aarch64-linux
     else
-        TOOLCHAIN=x86_64-linux-clang
+        TOOLCHAIN=x86_64-linux
     fi
 fi
 
@@ -60,6 +60,6 @@ cd ..
 
 # Build WASM.
 mkdir -p build-wasm && cd build-wasm
-cmake -DTOOLCHAIN=wasm-linux-clang -DTESTING=OFF ..
+cmake -DTOOLCHAIN=wasm32-wasi -DTESTING=OFF ..
 cmake --build . --parallel --target barretenberg.wasm
 cd ..

--- a/barretenberg/cmake/threading.cmake
+++ b/barretenberg/cmake/threading.cmake
@@ -1,4 +1,3 @@
-# TODO: Add brew to path if it exists so OpenMP can be discovered from it
 if(MULTITHREADING)
     find_package(OpenMP REQUIRED)
     message(STATUS "Multithreading is enabled.")

--- a/barretenberg/cmake/toolchain.cmake
+++ b/barretenberg/cmake/toolchain.cmake
@@ -1,6 +1,4 @@
-if(NOT TOOLCHAIN)
-  set(TOOLCHAIN "x86_64-linux-clang" CACHE STRING "Build toolchain." FORCE)
+if(NOT CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/toolchains/x86_64-linux.cmake")
 endif()
-message(STATUS "Toolchain: ${TOOLCHAIN}")
-
-include("./cmake/toolchains/${TOOLCHAIN}.cmake")
+message(STATUS "Toolchain: ${CMAKE_TOOLCHAIN_FILE}")

--- a/barretenberg/cmake/toolchains/aarch64-darwin.cmake
+++ b/barretenberg/cmake/toolchains/aarch64-darwin.cmake
@@ -1,7 +1,24 @@
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
-# TODO: Add brew to path if it exists so clang can be discovered from it
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+if (NOT $ENV{BREW_PREFIX} STREQUAL "")
+    set(CMAKE_C_COMPILER $ENV{BREW_PREFIX}/opt/llvm/bin/clang)
+    set(CMAKE_CXX_COMPILER $ENV{BREW_PREFIX}/opt/llvm/bin/clang++)
 
+    # This is a workaround until https://gitlab.kitware.com/cmake/cmake/-/commit/6e53d74147ef06b9acbd1d3045658cf6cc603a23
+    # is released and OpenMP_<lang>_INCLUDE_DIR should be useable to find the libomp
+    set(OpenMP_C_FLAGS "-fopenmp")
+    set(OpenMP_C_FLAGS_WORK "-fopenmp")
+    set(OpenMP_C_LIB_NAMES "libomp")
+    set(OpenMP_C_LIB_NAMES_WORK "libomp")
+    set(OpenMP_libomp_LIBRARY "$ENV{BREW_PREFIX}/opt/libomp/lib/libomp.dylib")
+
+    set(OpenMP_CXX_FLAGS "-fopenmp")
+    set(OpenMP_CXX_FLAGS_WORK "-fopenmp")
+    set(OpenMP_CXX_LIB_NAMES "libomp")
+    set(OpenMP_CXX_LIB_NAMES_WORK "libomp")
+    set(OpenMP_libomp_LIBRARY "$ENV{BREW_PREFIX}/opt/libomp/lib/libomp.dylib")
+else()
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+endif()

--- a/barretenberg/cmake/toolchains/wasm32-wasi.cmake
+++ b/barretenberg/cmake/toolchains/wasm32-wasi.cmake
@@ -2,3 +2,17 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set(CMAKE_SYSTEM_VERSION 1)
 
+if (WASI_SDK_PREFIX)
+    cmake_path(ABSOLUTE_PATH WASI_SDK_PREFIX NORMALIZE)
+
+    set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang)
+    set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++)
+    set(CMAKE_AR ${WASI_SDK_PREFIX}/bin/llvm-ar)
+    set(CMAKE_RANLIB ${WASI_SDK_PREFIX}/bin/llvm-ranlib)
+
+    set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot)
+    set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot)
+
+    set(CMAKE_C_COMPILER_WORKS ON)
+    set(CMAKE_CXX_COMPILER_WORKS ON)
+endif()

--- a/barretenberg/cmake/toolchains/x86_64-darwin.cmake
+++ b/barretenberg/cmake/toolchains/x86_64-darwin.cmake
@@ -1,7 +1,24 @@
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-# TODO: Add brew to path if it exists so clang can be discovered from it
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+if (NOT $ENV{BREW_PREFIX} STREQUAL "")
+    set(CMAKE_C_COMPILER $ENV{BREW_PREFIX}/opt/llvm/bin/clang)
+    set(CMAKE_CXX_COMPILER $ENV{BREW_PREFIX}/opt/llvm/bin/clang++)
 
+    # This is a workaround until https://gitlab.kitware.com/cmake/cmake/-/commit/6e53d74147ef06b9acbd1d3045658cf6cc603a23
+    # is released and OpenMP_<lang>_INCLUDE_DIR should be useable to find the libomp
+    set(OpenMP_C_FLAGS "-fopenmp")
+    set(OpenMP_C_FLAGS_WORK "-fopenmp")
+    set(OpenMP_C_LIB_NAMES "libomp")
+    set(OpenMP_C_LIB_NAMES_WORK "libomp")
+    set(OpenMP_libomp_LIBRARY "$ENV{BREW_PREFIX}/opt/libomp/lib/libomp.dylib")
+
+    set(OpenMP_CXX_FLAGS "-fopenmp")
+    set(OpenMP_CXX_FLAGS_WORK "-fopenmp")
+    set(OpenMP_CXX_LIB_NAMES "libomp")
+    set(OpenMP_CXX_LIB_NAMES_WORK "libomp")
+    set(OpenMP_libomp_LIBRARY "$ENV{BREW_PREFIX}/opt/libomp/lib/libomp.dylib")
+else()
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+endif()

--- a/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
+++ b/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
@@ -7,7 +7,28 @@ if(NOT WASM)
         FIND_PACKAGE_ARGS
     )
 
+    set(LEVELDB_BUILD_TESTS OFF CACHE BOOL "LevelDB tests off")
+    set(LEVELDB_BUILD_BENCHMARKS OFF CACHE BOOL "LevelDB benchmarks off")
+
     FetchContent_MakeAvailable(leveldb)
+
+    if (leveldb_SOURCE_DIR AND leveldb_BINARY_DIR)
+        set_property(DIRECTORY ${leveldb_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL)
+        set_property(DIRECTORY ${leveldb_BINARY_DIR} PROPERTY EXCLUDE_FROM_ALL)
+
+        target_compile_options(
+            leveldb
+            PRIVATE
+            -Wno-unknown-warning-option
+            -Wno-unused-but-set-variable
+            -Wno-sign-conversion
+            -Wno-unused-parameter
+            -Wno-shorten-64-to-32
+            -Wno-implicit-int-conversion
+            -Wno-conversion
+            -Wno-implicit-fallthrough
+        )
+    endif()
 
     link_libraries(leveldb)
 endif()

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -12,10 +12,10 @@ pub enum Arch {
 // These constants correspond to the filenames in cmake/toolchains
 //
 // There are currently no toolchain for windows, please use WSL
-const INTEL_APPLE: &str = "x86_64-apple-clang";
-const INTEL_LINUX: &str = "x86_64-linux-clang";
-const ARM_APPLE: &str = "arm-apple-clang";
-const ARM_LINUX: &str = "aarch64-linux-clang";
+const INTEL_APPLE: &str = "x86_64-darwin";
+const INTEL_LINUX: &str = "x86_64-linux";
+const ARM_APPLE: &str = "aarch64-darwin";
+const ARM_LINUX: &str = "aarch64-linux";
 
 fn select_toolchain() -> &'static str {
     let arch = select_arch();

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -84,7 +84,10 @@ fn main() {
         .cxxflag("-fPIC")
         .cxxflag("-fPIE")
         .env("NUM_JOBS", num_cpus::get().to_string())
-        .define("TOOLCHAIN", toolchain)
+        .define(
+            "CMAKE_TOOLCHAIN_FILE",
+            format!("./cmake/toolchains/{toolchain}.cmake"),
+        )
         .define("TESTING", "OFF")
         .always_configure(false)
         .build();


### PR DESCRIPTION
This restores the builds using brew and fixes up the bootstrap and rust build scripts. I added a comment to the brew libomp workaround because it should be fixed with a patch that landed last week, but it hasn't been released yet.

I also began the work to use the `CMAKE_TOOLCHAIN_FILE` file instead of `TOOLCHAIN` to support cross-compiling, as per the cmake docs.

With these changes, we should have builds working with & without nix on each supported platform. But work still needs to be done to get the cross-compiling to work.