### PR TITLE
feat(wrapper): Flake bindgen cleanup

### DIFF
--- a/.github/workflows/cross-linux.yml
+++ b/.github/workflows/cross-linux.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build barretenberg on ${{ matrix.target }}
         run: |
@@ -50,6 +51,7 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build barretenberg_wrapper
         working-directory: ./barretenberg_wrapper

--- a/.github/workflows/cross-linux.yml
+++ b/.github/workflows/cross-linux.yml
@@ -11,10 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          [
-            # llvm11, llvm12, llvm13, llvm14, wasm32, 
-            cross-aarch64-linux
+        target: [
+            # llvm11, llvm12, llvm13, llvm14, wasm32,
+            cross-aarch64-linux,
           ]
 
     steps:
@@ -25,7 +24,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-22.11
 
-      - name: Build ${{ matrix.target }}
+      - name: Build barretenberg on ${{ matrix.target }}
         run: |
           nix build -L .#${{ matrix.target }}
 
@@ -40,3 +39,22 @@ jobs:
           name: ${{ matrix.target }}
           path: ./artifacts/
           retention-days: 3
+
+  bb_wrapper:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+
+      - name: Build barretenberg_wrapper
+        working-directory: ./barretenberg_wrapper
+        # This removes the lockfile as a workaround to relative file paths causing a failure in flakes
+        run: |
+          rm flake.lock
+          nix build -L
+          ./result/bin/barretenberg_wrapper

--- a/.github/workflows/cross-mac.yml
+++ b/.github/workflows/cross-mac.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         target: [
-          # llvm11, llvm12, llvm13, llvm14, wasm32, 
-          cross-aarch64-darwin
-        ]
+            # llvm11, llvm12, llvm13, llvm14, wasm32,
+            cross-aarch64-darwin,
+          ]
 
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-22.11
 
-      - name: Build ${{ matrix.target }}
+      - name: Build barretenberg on ${{ matrix.target }}
         run: |
           nix build -L .#${{ matrix.target }}
 
@@ -39,3 +39,22 @@ jobs:
           name: ${{ matrix.target }}
           path: ./artifacts/
           retention-days: 3
+
+  bb_wrapper:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+
+      - name: Build barretenberg_wrapper
+        working-directory: ./barretenberg_wrapper
+        # This removes the lockfile as a workaround to relative file paths causing a failure in flakes
+        run: |
+          rm flake.lock
+          nix build -L
+          ./result/bin/barretenberg_wrapper

--- a/.github/workflows/cross-mac.yml
+++ b/.github/workflows/cross-mac.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build barretenberg on ${{ matrix.target }}
         run: |
@@ -50,6 +51,7 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build barretenberg_wrapper
         working-directory: ./barretenberg_wrapper

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -53,6 +53,10 @@
           # Bindegn needs this
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
 
+          BINDGEN_EXTRA_CLANG_ARGS = "-I${libbarretenberg}/include/aztec -L${libbarretenberg}";
+
+          RUSTFLAGS = "-L${libbarretenberg}/lib -lomp";
+
           buildInputs = [
             pkgs.llvmPackages.openmp            
             libbarretenberg

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -47,24 +47,17 @@
 
           doCheck = false;
 
-
-          LIBBARRETENBERG = libbarretenberg;
-
-          # Bindegn needs this
+          # Bindegn needs these
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
           BINDGEN_EXTRA_CLANG_ARGS = "-I${libbarretenberg}/include/aztec -L${libbarretenberg}";
-
           RUSTFLAGS = "-L${libbarretenberg}/lib -lomp";
 
           buildInputs = [
-            pkgs.llvmPackages.openmp            
+            pkgs.llvmPackages.openmp
             libbarretenberg
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             pkgs.libiconv
           ];
-
-          
         };
       in rec {
         checks = { inherit barretenberg_wrapper_crate; };
@@ -84,7 +77,7 @@
 
           buildInputs = packages.default.buildInputs ;
 
-          nativeBuildInputs = with pkgs; [             
+          nativeBuildInputs = with pkgs; [
             cargo
             rustc ];
         };


### PR DESCRIPTION
This makes some changes to the flake to pass `BINDGEN_EXTRA_CLANG_ARGS` and `RUSTFLAGS` so we don't need to try to try resolving the barretenberg path within `build.rs`

It also uses `header_contents` to create a `wrapper.h` file with just `#include <aztec/bb/bb.hpp>` instead of trying to reference the bb header by path (this allows us to benefit from the include machinery in the C compiler.

I really want the `build.rs` to become as close to as simple as we can do with nix, but I need to investigate more... it likely relies on how the barretenberg install target works.