### PR TITLE
fix(bb_wrapper): Restore rust linker flags to ensure clang

### DIFF
--- a/.github/workflows/cross-linux.yml
+++ b/.github/workflows/cross-linux.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-mac.yml
+++ b/.github/workflows/cross-mac.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/barretenberg_wrapper/.cargo/config.toml
+++ b/barretenberg_wrapper/.cargo/config.toml
@@ -1,0 +1,8 @@
+# This ensures Clang (instead of GCC) is used as a linker on Linux.
+# See https://github.com/rust-lang/rust/issues/71515#issuecomment-935020057
+# These should apply when used as a library, as per
+# https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -68,7 +68,7 @@ fn which_clang(clang_command: &'static str) -> Option<String> {
     let which_clang_command = Command::new("which")
         .arg(clang_command)
         .output()
-        .expect("Failed to execute which clang commang");
+        .expect("Failed to execute which clang command");
 
     if which_clang_command.status.success() {
         let path =
@@ -87,7 +87,7 @@ fn set_compiler(toolchain: &'static str) {
                 format!("{}/opt/llvm/bin/clang", find_brew_prefix()),
             );
             env::set_var(
-                "CXX",
+                CXX_ENV_KEY,
                 format!("{}/opt/llvm/bin/clang++", find_brew_prefix()),
             );
         }
@@ -243,8 +243,8 @@ fn main() {
             .clang_args(&["-xc++"])
             .header_contents("wrapper.h", "#include <aztec/bb/bb.hpp>")
             .generate()
-            .expect("Unable to generate bindings");
-    }
+            .expect("Unable to generate bindings")
+    };
 
     println!("cargo:rustc-link-lib=static=crypto_blake2s");
     println!("cargo:rustc-link-lib=static=env");


### PR DESCRIPTION
This restores the linker flags so linux rust stuff always uses clang. I tried various other options but nothing else works. I believe these were removed in an attempt to make cross-compiling work, but the CI is reporting that it works correctly now that we use musl for cross-compile.